### PR TITLE
Removing config.h include from nodegsettings.cc

### DIFF
--- a/node_modules/gsettingsBridge/nodegsettings/nodegsettings.cc
+++ b/node_modules/gsettingsBridge/nodegsettings/nodegsettings.cc
@@ -13,7 +13,6 @@ https://github.com/gpii/universal/LICENSE.txt
 #include <node.h>
 #include <v8.h>
 
-#include <config.h>
 #include <gio/gio.h>
 
 using namespace v8;


### PR DESCRIPTION
Hi all!

I got this error when building the linux module.
Concretely, with nodegsettings.cc, which isn't properly build using the "node-waf build".
I get this error:

$ node-waf build
Waf: Entering directory `/home/jhernandez/git/github/GPII_javihernandez_linux/node_modules/gsettingsBridge/nodegsettings/build'
[1/2] cxx: nodegsettings.cc -> build/Release/nodegsettings_1.o
../nodegsettings.cc:16:20: fatal error: config.h: No such file or directory
compilation terminated.
Waf: Leaving directory`/home/jhernandez/git/github/GPII_javihernandez_linux/node_modules/gsettingsBridge/nodegsettings/build'
Build failed:  -> task failed (err #1): 
    {task: cxx nodegsettings.cc -> nodegsettings_1.o}

I guess that this config.h headers isn't needed since I removed the line and all is working as expected.
That's the reason for this pull request, so, if there are objections to push this change, please let me know and let's see what is causing this issue.

Thanks and

kind regards!!
