### PR TITLE
Kasper's fix for USB drives with spaces in their names.

### DIFF
--- a/usbDriveListener/bin/handleUserDeviceEvent.sh
+++ b/usbDriveListener/bin/handleUserDeviceEvent.sh
@@ -22,8 +22,8 @@ if [ $1 -eq 1 ]; then
 		sleep 1
 	done
 
-	mountLocation=`mount | grep $2 |cut -d " " -f 3`
-	token=`cat $mountLocation/.gpii-user-token.txt`
+    mountLocation=`mount | grep $2 | sed -e "s#/[^ ]\+ [^ ]\+ \(.*\) type.*#\1#"`
+    token=`cat "$mountLocation/.gpii-user-token.txt"`
 	echo "User logged in on device $2 with token ${token}." >> "$logFilePath"
 	echo $2:$token >> "$usersFilePath"						# Keep the location and token in a users file.
 	curl http://localhost:8081/user/$token/login


### PR DESCRIPTION
Kasper, I've taken your changes from here:

https://github.com/GPII/linux/pull/6/files#diff-8

And merged them cleanly without all the other changes that were in your pull request. Can you double check that this works and push it if you're happy with it?
