### PR TITLE
Fix for issue GPII-8

### DIFF
--- a/node_modules/gsettingsBridge/gsettings_bridge.js
+++ b/node_modules/gsettingsBridge/gsettings_bridge.js
@@ -54,8 +54,9 @@ https://github.com/gpii/universal/LICENSE.txt
             for (var j = 0; j < app[appId].length; j++) {
                 var schemaId = app[appId][j].options.schema;
                 var settings = app[appId][j].settings;
+                var keys = nodeGSettings.get_gsetting_keys(schemaId);
+
                 if (settings === null) {
-                    var keys = nodeGSettings.get_gsetting_keys(schemaId);
                     app[appId][j].settings = {};
                     for (var k = 0; k < keys.length; k++) {
                         var key = keys[k];
@@ -64,6 +65,7 @@ https://github.com/gpii/universal/LICENSE.txt
                 }
                 else {
                     for (var settingKey in settings) {
+                        if (keys.indexOf(settingKey) == -1) continue;
                         settings[settingKey] = nodeGSettings.get_gsetting(schemaId,settingKey);
                     }
 
@@ -79,7 +81,10 @@ https://github.com/gpii/universal/LICENSE.txt
             for (var j = 0; j < app[appId].length; j++) {
                 var schemaId = app[appId][j].options.schema;
                 var settings = app[appId][j].settings;
+                var keys = nodeGSettings.get_gsetting_keys(schemaId);
+
                 for (var settingKey in settings) {
+                    if (keys.indexOf(settingKey) == -1) continue;
                     var value = settings[settingKey];
                     var oldValue = nodeGSettings.get_gsetting(schemaId,settingKey);
                     nodeGSettings.set_gsetting(schemaId,settingKey,value);


### PR DESCRIPTION
GSettingsHandler appears to core dump when trying to set a non-existent
key in a schema (see http://issues.gpii.net/browse/GPII-8)

The problem is that Gio.Settings segfaults when requesting a
non-existent key from a gsettings schema.

This fix checks if the setting matches with the gsettings schema before
each set/get.

Cheers!
Javi.
