### PR TITLE
GPII-78: USB Listener for Linux is unresponsive

### DIFF
--- a/usbDriveListener/80-gpii.rules
+++ b/usbDriveListener/80-gpii.rules
@@ -1,2 +1,2 @@
-KERNEL=="sd[a-z][0-9]", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/usr/local/gpii/bin/trigger.sh 1 /dev/%k"
-KERNEL=="sd[a-z][0-9]", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="remove", RUN+="/usr/local/gpii/bin/trigger.sh 0 /dev/%k"
+KERNEL=="sd[a-z]", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/usr/local/gpii/bin/trigger.sh 1 /dev/%k"
+KERNEL=="sd[a-z]", SUBSYSTEM=="block", SUBSYSTEMS=="usb", ACTION=="remove", RUN+="/usr/local/gpii/bin/trigger.sh 0 /dev/%k"


### PR DESCRIPTION
see JIRA: http://issues.gpii.net/browse/GPII-78

Removed the "partition number" restriction from the GPII's udev rule.

Cheers,
Javi
