### PR TITLE
GPII-658: Update configuration to use when running acceptance tests

### DIFF
--- a/tests/acceptanceTests/configs/builtIn_config.json
+++ b/tests/acceptanceTests/configs/builtIn_config.json
@@ -16,6 +16,6 @@
         }
     },
     "includes": [
-        "../../../../node_modules/universal/tests/acceptanceTests/configs/localInstall.json"
+        "../../../../node_modules/universal/tests/acceptanceTests/configs/localInstall_localPrefs.json"
     ]
 }

--- a/tests/acceptanceTests/configs/orca_config.json
+++ b/tests/acceptanceTests/configs/orca_config.json
@@ -16,6 +16,6 @@
         }
     },
     "includes": [
-        "../../../../node_modules/universal/tests/acceptanceTests/configs/localInstall.json"
+        "../../../../node_modules/universal/tests/acceptanceTests/configs/localInstall_localPrefs.json"
     ]
 }


### PR DESCRIPTION
This change is supposed to be included only into a newly created pilots2 branch of GPII/linux
