### PR TITLE
GPII-904: Fixing a typo that breaks alsaSettingsHandlerTests.js

### DIFF
--- a/gpii/node_modules/alsa/test/alsaSettingsHandlerTests.js
+++ b/gpii/node_modules/alsa/test/alsaSettingsHandlerTests.js
@@ -47,8 +47,8 @@ jqUnit.test("Running tests for ALSA Settings Handler", function () {
             payload["org.alsa-project"][0].settings.masterVolume);
 
     var newPayload = fluid.copy(payload);
-    newPayload["org.alsa-project"][0].settingsmasterVolume =
-        returnPayload["org.alsa-project"][0].settingsmasterVolume.oldValue;
+    newPayload["org.alsa-project"][0].settings.masterVolume =
+        returnPayload["org.alsa-project"][0].settings.masterVolume.oldValue;
 
     var lastPayload = alsa.set(newPayload);
 


### PR DESCRIPTION
http://issues.gpii.net/browse/GPII-904
