### PR TITLE
GPII-920: Modify installUsbLib and uninstallUsbLib grunt tasks to handle non-fatal errors gracefully.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,14 +60,14 @@ module.exports = function(grunt) {
                     "sudo cp " + usbListenerDir + "/gpii-usb-user-listener /usr/bin/",
                     "sudo cp " + usbListenerDir +
                         "/gpii-usb-user-listener.desktop /usr/share/applications/",
-                    "sudo mkdir /var/lib/gpii"
+                    "sudo mkdir -p /var/lib/gpii"
                 ].join("&&")
             },
             uninstallUsbLib: {
                 command: [
                     "sudo rm /usr/bin/gpii-usb-user-listener",
                     "sudo rm /usr/share/applications/gpii-usb-user-listener.desktop",
-                    "sudo rm -f /var/lib/gpii"
+                    "sudo rm -f -r /var/lib/gpii"
                 ].join("&&")
             },
             startGpii: {


### PR DESCRIPTION
Minor changes to the calls to 'mkdir' (installUsbLib) and 'rm' (uninstallUsbLib) to avoid "directory already exists" and "can't remove non-empty directory" errors.
