### PR TITLE
GPII-1025:  Move creation of GPII log directory to grunt task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
                     "sudo cp " + usbListenerDir + "/gpii-usb-user-listener /usr/bin/",
                     "sudo cp " + usbListenerDir +
                         "/gpii-usb-user-listener.desktop /usr/share/applications/",
-                    "sudo mkdir -p /var/lib/gpii"
+                    "sudo mkdir -p /var/lib/gpii",
                     "sudo touch /var/lib/gpii/log.txt",
                     "sudo chmod a+rw /var/lib/gpii/log.txt"
                 ].join("&&")


### PR DESCRIPTION
@javihernandez Here are the changes to the grunt build that change the GPII log file read/write permissions  -- everyone can read/write the log.
