### PR TITLE
GPII-1032:  Modified uninstallUsbLib grunt task (linux).

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,8 +67,8 @@ module.exports = function(grunt) {
             },
             uninstallUsbLib: {
                 command: [
-                    "sudo rm /usr/bin/gpii-usb-user-listener",
-                    "sudo rm /usr/share/applications/gpii-usb-user-listener.desktop",
+                    "sudo rm -f /usr/bin/gpii-usb-user-listener",
+                    "sudo rm -f /usr/share/applications/gpii-usb-user-listener.desktop",
                     "sudo rm -f -r /var/lib/gpii"
                 ].join("&&")
             },


### PR DESCRIPTION
@javihernandez or @kaspermarkus,

A couple more minor changes to the "uninstallUsbLib" grunt task for linux that avoids "no such file" errors when attempting to delete those files.
