### PR TITLE
GPII-629: Removed references to 'data' for the orca settings handler

### DIFF
--- a/gpii/node_modules/orca/test/orcaSettingsHandlerTests.js
+++ b/gpii/node_modules/orca/test/orcaSettingsHandlerTests.js
@@ -77,7 +77,7 @@ jqUnit.test("Running tests for Orca Settings Handler", function () {
     // Complete get/set flow with non-existent settings.
     //
     var getPayload2 = {
-        "data": [{
+        "app.id.goes.here": [{
             "settings": {
                 "foo": null,
                 "cat.name": null,
@@ -89,7 +89,7 @@ jqUnit.test("Running tests for Orca Settings Handler", function () {
     var defaultSettingsPayload2 = gpii.resolveSync(orca.get(getPayload2));
 
     var setPayload2 = {
-        "data": [{
+        "app.id.goes.here": [{
             "settings": {
                 "foo": "bar",
                 "cat.name": "CATTT",
@@ -99,9 +99,9 @@ jqUnit.test("Running tests for Orca Settings Handler", function () {
     };
 
     var returnPayload2 = gpii.resolveSync(orca.set(setPayload2));
-    var settings2 = fluid.copy(returnPayload2.data[0].settings);
+    var settings2 = fluid.copy(returnPayload2["app.id.goes.here"][0].settings);
     fluid.each(settings2, function (v, k) {
-        var expectedValue = setPayload2.data[0].settings[k];
+        var expectedValue = setPayload2["app.id.goes.here"][0].settings[k];
         jqUnit.assertDeepEq("Non-existent setting " + k + " is being set well", expectedValue, v.newValue);
     });
 


### PR DESCRIPTION
Changed orca settings handler tests to include more solution IDs as keys to ensure we're no longer dependent on the 'data' keyword