### PR TITLE
GPII-1137:  Remove "grunt start" from source and documentation.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,9 +71,6 @@ module.exports = function (grunt) {
                     "sudo rm -f /usr/share/applications/gpii-usb-user-listener.desktop",
                     "sudo rm -f -r /var/lib/gpii"
                 ].join("&&")
-            },
-            startGpii: {
-                command: "node gpii.js"
             }
         }
     });
@@ -91,10 +88,6 @@ module.exports = function (grunt) {
         grunt.task.run("shell:cleanAlsaBridge");
         grunt.task.run("shell:cleanXrandrBridge");
         grunt.task.run("shell:uninstallUsbLib");
-    });
-
-    grunt.registerTask("start", "Start the GPII", function () {
-        grunt.task.run("shell:startGpii");
     });
 
     grunt.registerTask("install", "Install system level GPII Components", function () {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To clean the plugin binaries use
 
 You can start the GPII local server on port 8080 using:
 
-    grunt start
+    node gpii.js
 
 To install and uninstall the listener components use the following. Note that
 this may prompt you for sudo access.


### PR DESCRIPTION
@javihernandez Here is the "Wipe out grunt's start task" for the linux branch.
