### PR TITLE
GPII-1168:  Check for second resolution before running xrandr test.

### DIFF
--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr.cc
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr.cc
@@ -235,31 +235,34 @@ Handle<Value> setScreenResolution(const Arguments& args) {
     char *displayname = NULL;
 
     dpy = XOpenDisplay (displayname);
-
     if (dpy == NULL) {
         printf ("Cannot open display %s\n", displayname);
-        return scope.Close(Boolean::New(False));
+        return scope.Close (Boolean::New(False));
     }
 
     int screen = DefaultScreen (dpy);
     Window root = RootWindow (dpy, screen);
-
-    XSelectInput (dpy, root, StructureNotifyMask);
-    XRRSelectInput (dpy, root, RRScreenChangeNotifyMask);
     int eventbase;
     int errorbase;
-    XRRQueryExtension(dpy, &eventbase, &errorbase);
-
+    if (!XRRQueryExtension(dpy, &eventbase, &errorbase)) {
+        printf ("RandR extension missing\n");
+        return scope.Close (Boolean::New(False));
+    }
     XRRScreenConfiguration *sc = XRRGetScreenInfo (dpy, root);
     if (sc == NULL) {
         printf ("Cannot get screen info\n");
-        return scope.Close(Boolean::New(False));
+        return scope.Close (Boolean::New(False));
     }
+    XSelectInput (dpy, root, StructureNotifyMask);
+    XRRSelectInput (dpy, root, RRScreenChangeNotifyMask);
+
+    Rotation current_rotation;
+    SizeID current_size;
+    current_size = XRRConfigCurrentConfiguration (sc, &current_rotation);
 
     int nsize;
     XRRScreenSize *sizes = XRRConfigSizes(sc, &nsize);
-    int sizeindex = 0;
-
+    SizeID sizeindex = 0;
     while (sizeindex < nsize) {
         if (sizes[sizeindex].width == width &&
         sizes[sizeindex].height == height)
@@ -269,44 +272,42 @@ Handle<Value> setScreenResolution(const Arguments& args) {
 
     if (sizeindex >= nsize) {
         printf ("%dx%d resolution not available\n", width, height);
-        return scope.Close(Boolean::New(False));
+        XRRFreeScreenConfigInfo (sc);
+        return scope.Close (Boolean::New(False));
     }
 
     Status status = XRRSetScreenConfig (dpy, sc,
                                         DefaultRootWindow (dpy),
-                                        (SizeID) sizeindex,
+                                        sizeindex,
                                         (Rotation) (rotation | reflection),
                                         CurrentTime);
-
-    XEvent event;
-    bool rcvdrrnotify = false;
-    bool rcvdconfignotify = false;
-
-    if (status == RRSetConfigSuccess) {
-        while (1) {
-            XNextEvent(dpy, (XEvent *) &event);
-            //printf ("Event received, type = %d\n", event.type);
-            XRRUpdateConfiguration (&event) ;
-            switch (event.type - eventbase) {
-                case RRScreenChangeNotify:
-                    rcvdrrnotify = true;
-                    break;
-                default:
-                    if (event.type == ConfigureNotify) {
-                        //printf("Rcvd ConfigureNotify Event!\n");
-                        rcvdconfignotify = true;
-                    } else {
-                        //printf("unknown event = %d!\n", event.type);
-                    }
-                    break;
-            }
-
-            if (rcvdrrnotify && rcvdconfignotify) {
-                break;
+    if (status == RRSetConfigFailed) {
+        printf ("Failed to change the screen resolution.\n");
+        XRRFreeScreenConfigInfo (sc);
+        return scope.Close (Boolean::New(False));
+    }
+    else { // status == RRSetConfigSuccess
+        if (sizeindex != current_size) {
+            XEvent event;
+            bool rcvdrrnotify = false;
+            while (!rcvdrrnotify) {
+                XNextEvent(dpy, (XEvent *) &event);
+                //printf ("Event received, type = %d\n", event.type);
+                XRRUpdateConfiguration (&event) ;
+                switch (event.type - eventbase) {
+                    case RRScreenChangeNotify:
+                        rcvdrrnotify = true;
+                        break;
+                    default:
+                        if (event.type != ConfigureNotify) {
+                            printf("unknown event = %d!\n", event.type);
+                        }
+                        break;
+                }
             }
         }
     }
-
+    XRRFreeScreenConfigInfo (sc);
     return scope.Close(Boolean::New(True));
 }
 

--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr.cc
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr.cc
@@ -301,7 +301,7 @@ Handle<Value> setScreenResolution(const Arguments& args) {
                     break;
             }
 
-            if (rcvdrrnotify && rcvdrrnotify) {
+            if (rcvdrrnotify && rcvdconfignotify) {
                 break;
             }
         }

--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
@@ -20,6 +20,18 @@ var fluid = require("universal"),
     jqUnit = fluid.require("jqUnit"),
     xrandr = require("./build/Release/nodexrandr.node");
 
+var convert = fluid.registerNamespace("gpii.tests.xrandr.convert");
+convert.toString = function (size) {
+    return size.width + "x" + size.height;
+};
+convert.toSize = function (sizeString) {
+    var wPos = sizeString.indexOf("x");
+    return {
+        width: parseInt(sizeString.substring(0, wPos), 10),
+        height: parseInt(sizeString.substring(wPos + 1), 10)
+    };
+};
+
 jqUnit.module("GPII Xrandr Module");
 
 jqUnit.test("Running tests for Xrandr Bridge", function () {
@@ -37,18 +49,34 @@ jqUnit.test("Running tests for Xrandr Bridge", function () {
     jqUnit.assertTrue("Checking that 'getDisplays' method is callable",
                       xrandr.getDisplays());
 
-    var resolution = xrandr.getDisplays()[0].resolution;
+    // Get the current resolution, and see if there is a different available
+    // resolution.
+    //
+    var display = xrandr.getDisplays()[0];
+    var resolution0 = convert.toString(display.resolution);
+    var newResolution = fluid.find(display.available_resolutions, function (aResolution) {
+        if (resolution0 !== aResolution) {
+            return (convert.toSize(aResolution));
+        }
+    }, null);
 
-    jqUnit.assertTrue("Checking that 'setScreenSize' is callable",
-                      xrandr.setScreenResolution(800, 600));
+    if (newResolution !== null) {
+        var oldResolution = display.resolution;
 
-    jqUnit.assertDeepEq("Checking that 'setScreenSize' sets the resolution",
-                        xrandr.getDisplays()[0].resolution,
-                        {width: 800, height: 600, mwidth: resolution.mwidth,
-                         mheight: resolution.mheight});
+        jqUnit.assertTrue("Checking that 'setScreenSize' is callable",
+                          xrandr.setScreenResolution(
+                            newResolution.width, newResolution.height));
 
-    xrandr.setScreenResolution(resolution.width, resolution.height);
-    jqUnit.assertDeepEq("Checking that 'setScreenSize' sets the resolution",
-                        xrandr.getDisplays()[0].resolution,
-                        resolution);
+        jqUnit.assertDeepEq("Checking that 'setScreenSize' sets the resolution",
+                            xrandr.getDisplays()[0].resolution,
+                            {width: newResolution.width,
+                             height: newResolution.height,
+                             mwidth: oldResolution.mwidth,
+                             mheight: oldResolution.mheight});
+
+        xrandr.setScreenResolution(oldResolution.width, oldResolution.height);
+        jqUnit.assertDeepEq("Checking that 'setScreenSize' sets the resolution",
+                            xrandr.getDisplays()[0].resolution,
+                            oldResolution);
+    }
 });

--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
@@ -49,17 +49,26 @@ jqUnit.test("Running tests for Xrandr Bridge", function () {
     jqUnit.assertTrue("Checking that 'getDisplays' method is callable",
                       xrandr.getDisplays());
 
-    // Get the current resolution, and see if there is a different available
-    // resolution.
+    // Get the current resolution.  Use a value below its minimum size to check
+    // that setScreenResolution() correctly returns false (can't set an
+    // impossible resolution).
     //
     var display = xrandr.getDisplays()[0];
+    jqUnit.assertFalse ("Checking 'setScreenResolution' with impossible size",
+                        xrandr.setScreenResolution(
+                            display.resolution.mwidth - 1,
+                            display.resolution.mheight - 1)
+                        );
+
+    // Convert the current resolution to a string, and see if there is a
+    // different available resolution to test setScreenResolution().
+    //
     var resolution0 = convert.toString(display.resolution);
     var newResolution = fluid.find(display.available_resolutions, function (aResolution) {
         if (resolution0 !== aResolution) {
             return (convert.toSize(aResolution));
         }
     }, null);
-
     if (newResolution !== null) {
         var oldResolution = display.resolution;
 


### PR DESCRIPTION
@javihernandez Here's a pull request against the current linux 'master' for fixing the xrandr 'setScreenResolution()' test failures: run only under the condition that there is at least one other resolution available to test.
