### PR TITLE
GPII-1289: Makes UnitTests.sh return non-zero exit code on failures

### DIFF
--- a/tests/UnitTests.sh
+++ b/tests/UnitTests.sh
@@ -13,6 +13,8 @@
 # You may obtain a copy of the License at
 # https://github.com/gpii/universal/LICENSE.txt
 
+set -e
+
 pushd .
 cd ../gpii/node_modules/alsa/test
 node alsaSettingsHandlerTests.js


### PR DESCRIPTION
@javihernandez, @kaspermarkus You can find more details at https://issues.gpii.net/browse/GPII-1289