### PR TITLE
#GPII-1740: Implement automatic build of Linux Package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,6 +98,9 @@ module.exports = function (grunt) {
             prepareRpmEnv: {
                 command: "dnf install -y nodejs-grunt-cli npm alsa-lib-devel json-glib-devel PackageKit-glib-devel libXrandr-devel libgnome-keyring-devel sudo @development-tools rpmdevtools"
             },
+            buildRpmDocker: {
+                command: "docker run --rm -i -v $(pwd):/sync fedora /bin/bash -c 'dnf install -y nodejs-grunt-cli; cp -r /sync /packages; cd /packages; grunt buildrpm; cp -r /packages/bin /sync'"
+            },
             runAcceptanceTests: {
                 command: "vagrant ssh -c 'DISPLAY=:0 node /home/vagrant/sync/tests/AcceptanceTests.js'"
             },
@@ -176,6 +179,9 @@ module.exports = function (grunt) {
     grunt.registerTask("tests", "Run GPII unit and acceptance tests", function () {
         grunt.task.run("shell:runUnitTests");
         grunt.task.run("shell:runAcceptanceTests");
+    });
+    grunt.registerTask("buildRpmDocker", "Build Linux RPM package using a Docker container", function () {
+        grunt.task.run("shell:buildRpmDocker");
     });
     grunt.registerTask("buildrpm", "Build GPII Linux and RPM package", function () {
         grunt.task.run("shell:prepareRpmEnv");

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,6 +126,7 @@ module.exports = function (grunt) {
                     {src: "../node_modules/**/*", dest: "/opt/gpii-linux/node_modules"},
                     {src: "gpii-linux-autostart.desktop", dest: "/etc/xdg/autostart", cwd: 'build/resources'},
                     {src: "gpii-linux-start", dest: "/usr/bin", cwd: 'build/resources'},
+                    {src: "/var/lib/gpii/log.txt", dest: "/", mode: 666},
                     {src: "gpii-usb-user-listener", dest: "/usr/bin", mode: "755", cwd: 'usbDriveListener'},
                     {src: "gpii-usb-user-listener.desktop", dest: "/usr/share/applications", cwd: 'usbDriveListener'}
                 ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,7 +99,7 @@ module.exports = function (grunt) {
                 command: "dnf install -y nodejs-grunt-cli npm alsa-lib-devel json-glib-devel PackageKit-glib-devel libXrandr-devel libgnome-keyring-devel sudo @development-tools rpmdevtools"
             },
             buildRpmDocker: {
-                command: "docker run --rm -i -v $(pwd):/sync fedora /bin/bash -c 'dnf install -y nodejs-grunt-cli; cp -r /sync /packages; cd /packages; grunt buildrpm; cp -r /packages/bin /sync'"
+                command: "docker run --rm -i -v $(pwd):/sync fedora /bin/bash -c 'dnf install -y nodejs-grunt-cli; cp -r /sync /packages; cd /packages; grunt build-rpm; cp -r /packages/bin /sync'"
             },
             runAcceptanceTests: {
                 command: "vagrant ssh -c 'DISPLAY=:0 node /home/vagrant/sync/tests/AcceptanceTests.js'"
@@ -180,10 +180,10 @@ module.exports = function (grunt) {
         grunt.task.run("shell:runUnitTests");
         grunt.task.run("shell:runAcceptanceTests");
     });
-    grunt.registerTask("buildRpmDocker", "Build Linux RPM package using a Docker container", function () {
+    grunt.registerTask("build-rpm-docker", "Build Linux RPM package using a Docker container", function () {
         grunt.task.run("shell:buildRpmDocker");
     });
-    grunt.registerTask("buildrpm", "Build GPII Linux and RPM package", function () {
+    grunt.registerTask("build-rpm", "Build GPII Linux and RPM package", function () {
         grunt.task.run("shell:prepareRpmEnv");
         grunt.task.run("build");
         grunt.task.run("easy_rpm");

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,6 +23,16 @@ module.exports = function (grunt) {
     var usbListenerDir = "./usbDriveListener";
     var gypCompileCmd = "node-gyp configure build";
     var gypCleanCmd = "node-gyp clean";
+    var pkgdata = require('./package.json');
+
+    var currentArch = (function() {
+        if (process.arch == 'ia32')
+            return 'i386';
+        else if (process.arch == 'x64')
+            return "x86_64";
+        else
+            return "noarch";
+    })();
 
     function nodeGypShell(cmd, cwd) {
         return {
@@ -46,6 +56,9 @@ module.exports = function (grunt) {
         jsonlint: {
             src: ["gpii/**/*.json", "tests/**/*.json"]
         },
+        appFileName: "gpii-linux",
+        buildDir: "build",
+        pkgdata: pkgdata,
         shell: {
             options: {
                 stdout: true,
@@ -88,6 +101,38 @@ module.exports = function (grunt) {
             runUnitTests: {
                 command: "vagrant ssh -c 'cd /home/vagrant/sync/tests/; DISPLAY=:0 ./UnitTests.sh'"
             }
+        },
+        easy_rpm: {
+            options: {
+                release: 1,
+                summary: pkgdata.description,
+                rpmDestination: "bin",
+                tempDir: "bin/tmp",
+                keepTemp: true,
+                license: pkgdata.licenses[0].type,
+                url: pkgdata.homepage,
+                buildArch: currentArch,
+                requires: [
+                    "nodejs >= 0.10.42",
+                    "python-httplib2"
+                ]
+            },
+            release: {
+                files: [
+                    {src: "gpii.js", dest: "/opt/gpii-linux"},
+                    {src: "index.js", dest: "/opt/gpii-linux"},
+                    {src: "package.json", dest: "/opt/gpii-linux"},
+                    {src: "gpii/**/*", dest: "/opt/gpii-linux"},
+                    {src: "../node_modules/**/*", dest: "/opt/gpii-linux/node_modules"},
+                    {src: "gpii-linux-autostart.desktop", dest: "/etc/xdg/autostart", cwd: 'build/resources'},
+                    {src: "gpii-linux-start", dest: "/usr/bin", cwd: 'build/resources'},
+                    {src: "gpii-usb-user-listener", dest: "/usr/bin", mode: "755", cwd: 'usbDriveListener'},
+                    {src: "gpii-usb-user-listener.desktop", dest: "/usr/share/applications", cwd: 'usbDriveListener'}
+                ],
+                excludeFiles: [
+                    "../node_modules/**/examples/switch-bench.js" //avoid strange dependency
+                ]
+            },
         }
     });
 
@@ -128,4 +173,9 @@ module.exports = function (grunt) {
         grunt.task.run("shell:runUnitTests");
         grunt.task.run("shell:runAcceptanceTests");
     });
+    grunt.registerTask("buildrpm", "Build GPII Linux and RPM package", function () {
+        grunt.task.run("build");
+        grunt.task.run("easy_rpm");
+    });
+    grunt.loadNpmTasks("grunt-easy-rpm");
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,6 +95,9 @@ module.exports = function (grunt) {
                     "sudo rm -f -r /var/lib/gpii"
                 ].join("&&")
             },
+            prepareRpmEnv: {
+                command: "dnf install -y nodejs-grunt-cli npm alsa-lib-devel json-glib-devel PackageKit-glib-devel libXrandr-devel libgnome-keyring-devel sudo @development-tools rpmdevtools"
+            },
             runAcceptanceTests: {
                 command: "vagrant ssh -c 'DISPLAY=:0 node /home/vagrant/sync/tests/AcceptanceTests.js'"
             },
@@ -175,6 +178,7 @@ module.exports = function (grunt) {
         grunt.task.run("shell:runAcceptanceTests");
     });
     grunt.registerTask("buildrpm", "Build GPII Linux and RPM package", function () {
+        grunt.task.run("shell:prepareRpmEnv");
         grunt.task.run("build");
         grunt.task.run("easy_rpm");
     });

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ to polute your environment.
 
 To build a RPM package run the following command at the root of the git repository:
 
-    docker run --rm -it \
-    -v $(pwd):/sync fedora \
-    /bin/bash -c "dnf install -y nodejs-grunt-cli; cp -r /sync /packages; cd /packages; grunt buildrpm; cp -r /packages/bin /sync"
+    grunt buildRpmDocker
 
 you will get the rpm package and the source files of the package in the ``bin``
 directory.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ this may prompt you for sudo access.
     grunt install
     grunt uninstall
 
+## Building a RPM package
+
+We use Docker to build the RPM package in a clean environment, this also avoids
+to polute your environment.
+
+To build a RPM package run the following command at the root of the git repository:
+
+    docker run --rm -it \
+    -v $(pwd):/sync fedora \
+    /bin/bash -c "dnf install -y nodejs-grunt-cli; cp -r /sync /packages; cd /packages; grunt buildrpm; cp -r /packages/bin /sync"
+
+you will get the rpm package and the source files of the package in the ``bin``
+directory.
+
 # Setting Up a Virtual Machine
 
 This repository contains content that will allow you to automatically provision a development VM. A [Vagrantfile](http://docs.vagrantup.com/v2/vagrantfile/) is provided that downloads a [Fedora Vagrant box](https://github.com/idi-ops/packer-fedora), starts a VM, and deploys the GPII Framework on it.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to polute your environment.
 
 To build a RPM package run the following command at the root of the git repository:
 
-    grunt buildRpmDocker
+    grunt build-rpm-docker
 
 you will get the rpm package and the source files of the package in the ``bin``
 directory.

--- a/build/resources/gpii-linux-autostart.desktop
+++ b/build/resources/gpii-linux-autostart.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Name=GPII Linux
+Exec=/usr/bin/gpii-linux-start
+OnlyShowIn=GNOME;

--- a/build/resources/gpii-linux-start
+++ b/build/resources/gpii-linux-start
@@ -1,0 +1,5 @@
+#!/bin/sh
+systemctl --user import-environment
+env > /tmp/env.gpii
+cd /opt/gpii-linux
+node gpii.js

--- a/build/resources/gpii-linux-start
+++ b/build/resources/gpii-linux-start
@@ -1,5 +1,4 @@
 #!/bin/sh
 systemctl --user import-environment
-env > /tmp/env.gpii
 cd /opt/gpii-linux
 node gpii.js

--- a/build/resources/gpii-linux.service
+++ b/build/resources/gpii-linux.service
@@ -1,0 +1,14 @@
+# Use with Systemd > 219
+[Unit]
+Description=omponents of the GPII personalization infrastructure for use on Linux
+Documentation=http://gpii.net
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/gpii-linux-start
+WorkingDirectory=/opt/gpii-linux
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+

--- a/build/resources/gpii-linux.service
+++ b/build/resources/gpii-linux.service
@@ -1,6 +1,6 @@
 # Use with Systemd > 219
 [Unit]
-Description=omponents of the GPII personalization infrastructure for use on Linux
+Description=Components of the GPII personalization infrastructure for use on Linux
 Documentation=http://gpii.net
 
 [Service]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "grunt-shell": "0.6.4",
     "grunt-contrib-jshint": "~0.9.0",
     "grunt-jsonlint": "1.0.4",
-    "grunt-gpii": "git://github.com/GPII/grunt-gpii.git#ec8412064e107febb120f0b7437d403453b40d2d"
+    "grunt-gpii": "git://github.com/GPII/grunt-gpii.git#ec8412064e107febb120f0b7437d403453b40d2d",
+    "grunt-easy-rpm": "1.5.5"
   },
   "licenses": [
     {


### PR DESCRIPTION
This PR allows to build a bundle RPM package of GPII-Linux and GPII-universal from a snapshot of GIT. The package installs all the files at /opt/gpii-linux of the distribution and sets the launch of GPII when the user logs in.

More info at Jira issue: #GPII-1740