### PR TITLE
GPII-679: licence URLs & EU funding acknowledgement.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://github.com/gpii/universal/LICENSE.txt
+https://github.com/GPII/linux/blob/master/LICENSE.txt
 */
 
 "use strict";

--- a/gpii.js
+++ b/gpii.js
@@ -7,12 +7,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 

--- a/gpii/node_modules/alsa/alsa_bridge.js
+++ b/gpii/node_modules/alsa/alsa_bridge.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 (function () {

--- a/gpii/node_modules/alsa/nodealsa/nodealsa.cc
+++ b/gpii/node_modules/alsa/nodealsa/nodealsa.cc
@@ -7,12 +7,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 #include <nan.h>

--- a/gpii/node_modules/alsa/nodealsa/nodealsa_tests.js
+++ b/gpii/node_modules/alsa/nodealsa/nodealsa_tests.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 "use strict";

--- a/gpii/node_modules/alsa/test/alsaSettingsHandlerTests.js
+++ b/gpii/node_modules/alsa/test/alsaSettingsHandlerTests.js
@@ -1,13 +1,17 @@
 /*
-GPII Node.js ALSA Volume Bridge
-
-Copyright 2013 Emergya
-
-Licensed under the New BSD license. You may not use this file except in
-compliance with this License.
-
-You may obtain a copy of the License at
-https://github.com/gpii/universal/LICENSE.txt
+    GPII Node.js ALSA Volume Bridge
+    
+    Copyright 2013 Emergya
+    
+    Licensed under the New BSD license. You may not use this file except in
+    compliance with this License.
+    
+    You may obtain a copy of the License at
+    https://github.com/GPII/linux/blob/master/LICENSE.txt
+    
+    The research leading to these results has received funding from the European Union's
+    Seventh Framework Programme (FP7/2007-2013)
+    under grant agreement no. 289016.
 */
 
 "use strict";

--- a/gpii/node_modules/gsettingsBridge/gsettings_bridge.js
+++ b/gpii/node_modules/gsettingsBridge/gsettings_bridge.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 (function () {

--- a/gpii/node_modules/gsettingsBridge/index.js
+++ b/gpii/node_modules/gsettingsBridge/index.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 require("./gsettings_bridge.js");

--- a/gpii/node_modules/gsettingsBridge/nodegsettings/nodegsettings.cc
+++ b/gpii/node_modules/gsettingsBridge/nodegsettings/nodegsettings.cc
@@ -7,12 +7,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 

--- a/gpii/node_modules/gsettingsBridge/nodegsettings/nodegsettings_tests.js
+++ b/gpii/node_modules/gsettingsBridge/nodegsettings/nodegsettings_tests.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 "use strict";

--- a/gpii/node_modules/gsettingsBridge/tests/gsettingsTests.js
+++ b/gpii/node_modules/gsettingsBridge/tests/gsettingsTests.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 "use strict";

--- a/gpii/node_modules/gsettingsBridge/tests/runUnitTests.sh
+++ b/gpii/node_modules/gsettingsBridge/tests/runUnitTests.sh
@@ -5,12 +5,12 @@
 # Licensed under the New BSD license. You may not use this file except in
 # compliance with this License.
 #
+# You may obtain a copy of the License at
+# https://github.com/GPII/linux/blob/master/LICENSE.txt
+#
 # The research leading to these results has received funding from the European Union's
 # Seventh Framework Programme (FP7/2007-2013)
 # under grant agreement no. 289016.
-#
-# You may obtain a copy of the License at
-# https://github.com/GPII/universal/blob/master/LICENSE.txt
 
 #!/bin/bash
 LOC="/usr/share/glib-2.0/schemas"

--- a/gpii/node_modules/orca/index.js
+++ b/gpii/node_modules/orca/index.js
@@ -7,12 +7,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 require("./orcaSettingsHandler.js");

--- a/gpii/node_modules/orca/orcaSettingsHandler.js
+++ b/gpii/node_modules/orca/orcaSettingsHandler.js
@@ -7,12 +7,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 (function () {

--- a/gpii/node_modules/orca/test/orcaSettingsHandlerTests.js
+++ b/gpii/node_modules/orca/test/orcaSettingsHandlerTests.js
@@ -7,12 +7,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 "use strict";

--- a/gpii/node_modules/packagekit/index.js
+++ b/gpii/node_modules/packagekit/index.js
@@ -7,7 +7,11 @@
  * compliance with this License.
  *
  * You may obtain a copy of the License at
- * https://github.com/gpii/universal/LICENSE.txt
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
  */
 
 var fluid = require("universal");

--- a/gpii/node_modules/packagekit/packageKitDeviceReporter.js
+++ b/gpii/node_modules/packagekit/packageKitDeviceReporter.js
@@ -7,7 +7,11 @@
  * compliance with this License.
  *
  * You may obtain a copy of the License at
- * https://github.com/gpii/universal/LICENSE.txt
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
  */
 
 (function () {

--- a/gpii/node_modules/packagekit/test/packageKitDeviceReporterTests.js
+++ b/gpii/node_modules/packagekit/test/packageKitDeviceReporterTests.js
@@ -7,7 +7,11 @@
  * compliance with this License.
  *
  * You may obtain a copy of the License at
- * https://github.com/gpii/universal/LICENSE.txt
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
  */
 "use strict";
 

--- a/gpii/node_modules/packagekit/test/packageKitModuleTests.js
+++ b/gpii/node_modules/packagekit/test/packageKitModuleTests.js
@@ -7,7 +7,11 @@
  * compliance with this License.
  *
  * You may obtain a copy of the License at
- * https://github.com/gpii/universal/LICENSE.txt
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
  */
 "use strict";
 

--- a/gpii/node_modules/xrandr/index.js
+++ b/gpii/node_modules/xrandr/index.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 require("./xrandr_bridge.js");

--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr.cc
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr.cc
@@ -7,12 +7,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 #include <nan.h>

--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 "use strict";

--- a/gpii/node_modules/xrandr/test/xrandrSettingsHandlerTests.js
+++ b/gpii/node_modules/xrandr/test/xrandrSettingsHandlerTests.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 "use strict";

--- a/gpii/node_modules/xrandr/xrandr_bridge.js
+++ b/gpii/node_modules/xrandr/xrandr_bridge.js
@@ -6,12 +6,12 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
 
 (function () {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
- /*
+/*
  * GPII Linux Personalization Framework Node.js Index
  *
  * Copyright 2012 OCAD University
@@ -7,14 +7,14 @@
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
  *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/linux/blob/master/LICENSE.txt
+ *
  * The research leading to these results has received funding from the European Union's
  * Seventh Framework Programme (FP7/2007-2013)
  * under grant agreement no. 289016.
- *
- * You may obtain a copy of the License at
- * https://github.com/GPII/universal/blob/master/LICENSE.txt
  */
- 
+
 var fluid = require("universal");
 
 fluid.module.register("gpii-linux", __dirname, require);

--- a/tests/AcceptanceTests.js
+++ b/tests/AcceptanceTests.js
@@ -7,11 +7,11 @@ Copyright 2014 Lucendo Development Ltd.
 Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
+You may obtain a copy of the License at
+https://github.com/GPII/linux/blob/master/LICENSE.txt
+
 The research leading to these results has received funding from the European Union's
 Seventh Framework Programme (FP7/2007-2013) under grant agreement no. 289016.
-
-You may obtain a copy of the License at
-https://github.com/gpii/universal/LICENSE.txt
 */
 
 "use strict";

--- a/tests/UnitTests.sh
+++ b/tests/UnitTests.sh
@@ -7,11 +7,11 @@
 # Licensed under the New BSD license. You may not use this file except in
 # compliance with this License.
 #
+# You may obtain a copy of the License at
+# https://github.com/GPII/linux/blob/master/LICENSE.txt
+#
 # The research leading to these results has received funding from the European Union's
 # Seventh Framework Programme (FP7/2007-2013) under grant agreement no. 289016.
-#
-# You may obtain a copy of the License at
-# https://github.com/gpii/universal/LICENSE.txt
 
 pushd .
 cd ../gpii/node_modules/alsa/test

--- a/usbDriveListener/gpii-usb-user-listener
+++ b/usbDriveListener/gpii-usb-user-listener
@@ -8,12 +8,12 @@
 # Licensed under the New BSD license. You may not use this file except in
 # compliance with this License.
 #
+# You may obtain a copy of the License at
+# https://github.com/GPII/linux/blob/master/LICENSE.txt
+#
 # The research leading to these results has received funding from the European Union's
 # Seventh Framework Programme (FP7/2007-2013)
 # under grant agreement no. 289016.
-#
-# You may obtain a copy of the License at
-# https://github.com/GPII/universal/blob/master/LICENSE.txt
 
 from gi.repository import GUdev
 from gi.repository import GLib


### PR DESCRIPTION
Some licence URLs did not work or pointed to the universal repo. Also, it makes more sense to put the EU funding acknowledgement below the licence URL.