### PR TITLE
GPII-1289: Makes unit tests shell script return accurate error codes

### DIFF
--- a/tests/UnitTests.sh
+++ b/tests/UnitTests.sh
@@ -13,6 +13,10 @@
 # The research leading to these results has received funding from the European Union's
 # Seventh Framework Programme (FP7/2007-2013) under grant agreement no. 289016.
 
+declare -i error_code
+
+trap 'error_code=$?' ERR EXIT
+
 pushd .
 cd ../gpii/node_modules/alsa/test
 node alsaSettingsHandlerTests.js
@@ -40,3 +44,9 @@ popd
 # These XRANDR tests crash out on my system (AMB - Fedora 19 64-bit in VMWare Workstation 10.0.1 on Windows 7 64-bit) 
 node ../gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
 node ../gpii/node_modules/xrandr/test/xrandrSettingsHandlerTests.js
+
+if [ -n "$error_code" ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
My changes from commit 7165ad43998c808c0c2d6570819ede64d3e96c3e overwrote the ``UnitTests.sh`` script by mistake. These changes make the script report accurate errors again. This time the script will not stop executing upon encountering the first test failure. Instead all tests will be run and if there's one or more tests that failed then a non-zero exit status will be returned.