### PR TITLE
GPII-1898: Update linux to node 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "bugs": "http://issues.gpii.net/browse/GPII",
     "homepage": "http://gpii.net/",
     "dependencies": {
-        "universal": "gpii/universal#98561d07c0b49d4d565be9027adebf36c1d1fe82"
+        "universal": "javihernandez/universal#be9dce824ad6cb027e10f4eb9d57e52f6b4847d7"
     },
     "devDependencies": {
         "grunt": "1.0.1",
         "fluid-grunt-eslint": "18.1.1",
         "grunt-jsonlint": "1.0.4",
         "grunt-shell": "1.3.0",
-        "nan": "2.1.0"
+        "nan": "2.4.0"
     },
     "license" : "BSD-3-Clause",
     "keywords": [
@@ -29,6 +29,6 @@
     "repository": "git://github.com/GPII/linux.git",
     "main": "./gpii/index.js",
     "engines": {
-        "node": ">=4.2.1"
+        "node": ">=6.3.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bugs": "http://issues.gpii.net/browse/GPII",
     "homepage": "http://gpii.net/",
     "dependencies": {
-        "universal": "javihernandez/universal#be9dce824ad6cb027e10f4eb9d57e52f6b4847d7"
+        "universal": "javihernandez/universal#570143d4822ae1cd8a4b9e1ef27b0e82d84b7fe9"
     },
     "devDependencies": {
         "grunt": "1.0.1",
@@ -29,6 +29,6 @@
     "repository": "git://github.com/GPII/linux.git",
     "main": "./gpii/index.js",
     "engines": {
-        "node": ">=6.3.1"
+        "node": ">=4.2.1"
     }
 }

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -1,7 +1,8 @@
 - src: https://github.com/idi-ops/ansible-facts
   name: facts
 
-- src: https://github.com/idi-ops/ansible-nodejs
+- src: https://github.com/javihernandez/ansible-nodejs
+  version: GPII-1898
   name: nodejs
 
 - src: https://github.com/gpii-ops/ansible-gpii-framework

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -1,8 +1,7 @@
 - src: https://github.com/idi-ops/ansible-facts
   name: facts
 
-- src: https://github.com/javihernandez/ansible-nodejs
-  version: GPII-1898
+- src: https://github.com/idi-ops/ansible-nodejs
   name: nodejs
 
 - src: https://github.com/gpii-ops/ansible-gpii-framework

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -9,7 +9,7 @@ nodejs_app_git_repo: https://github.com/gpii/linux.git
 nodejs_app_git_branch: master
 
 # Currently Node.js LTS (4.x or "Argon") is required by the GPII
-nodejs_branch: lts
+nodejs_branch: current
 
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 1.4.28


### PR DESCRIPTION
Note that updated references to universal and ansible-nodejs must be updated before merging this pull request.