### PR TITLE
GPII-580: Added registration of Infusion ContextAwareness marker 

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,19 @@ var fluid = require("universal");
 
 fluid.module.register("gpii-linux", __dirname, require);
 
+fluid.contextAware.makeChecks({
+    "gpii.contexts.linux": {
+        value: true
+    }
+});
+
 // Settings Handlers
-//
+
 require("./gpii/node_modules/gsettingsBridge");
 require("./gpii/node_modules/orca");
 require("./gpii/node_modules/alsa");
 require("./gpii/node_modules/xrandr");
 
 // Device Reporters
-//
+
 require("./gpii/node_modules/packagekit");


### PR DESCRIPTION
representing Linux platform for use in Journalling component and other contexts

This pull request partners GPII/universal#463 but does not depend on it