### PR TITLE
GPII-2085 - Switch node.js version from 'current' to 'lts'

### DIFF
--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -8,8 +8,8 @@ nodejs_app_git_repo: https://github.com/gpii/linux.git
 
 nodejs_app_git_branch: master
 
-# Currently Node.js LTS (4.x or "Argon") is required by the GPII
-nodejs_branch: current
+# Currently Node.js 6.x LTS is required by the GPII
+nodejs_branch: lts
 
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 1.4.28


### PR DESCRIPTION
It seems 'current' was being used and got committed to this repository as to make use of node.js 6.x (which wasn't released as a 'lts' release at the time).

This commit reverts that change since now node 6.x is a LTS release.

This should be a no-op. 