### PR TITLE
GSettingsHandler bridge can still cause core dumps for undefined keys.

### DIFF
--- a/gpii/node_modules/gsettingsBridge/gsettings_bridge.js
+++ b/gpii/node_modules/gsettingsBridge/gsettings_bridge.js
@@ -41,11 +41,20 @@ fluid.defaults("gpii.gsettings.getSingleKey", {
 });
 
 gpii.gsettings.getSingleKey = function (schemaId, key) {
-    return nodeGSettings.get_gsetting(schemaId, key);
+    var keys = nodeGSettings.get_gsetting_keys(schemaId);
+    if (keys.indexOf(key) !== -1) {
+        return nodeGSettings.get_gsetting(schemaId, key);
+    }
+    else {
+        return undefined;
+    }
 };
 
 gpii.gsettings.setSingleKey = function (schemaId, key, value) {
-    nodeGSettings.set_gsetting(schemaId, key, value);
+    var keys = nodeGSettings.get_gsetting_keys(schemaId);
+    if (keys.indexOf(key) !== -1) {
+        nodeGSettings.set_gsetting(schemaId, key, value);
+    }
 };
 
 gpii.gsettings.get = function (settingsarray) {

--- a/gpii/node_modules/gsettingsBridge/gsettings_bridge.js
+++ b/gpii/node_modules/gsettingsBridge/gsettings_bridge.js
@@ -44,8 +44,7 @@ gpii.gsettings.getSingleKey = function (schemaId, key) {
     var keys = nodeGSettings.get_gsetting_keys(schemaId);
     if (keys.indexOf(key) !== -1) {
         return nodeGSettings.get_gsetting(schemaId, key);
-    }
-    else {
+    } else {
         return undefined;
     }
 };

--- a/gpii/node_modules/gsettingsBridge/tests/gsettingsTests.js
+++ b/gpii/node_modules/gsettingsBridge/tests/gsettingsTests.js
@@ -193,7 +193,7 @@ jqUnit.test("Getting single keys via gsettings handler", function () {
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "boolean-setting"));
     jqUnit.assertEquals("Checking 'string' key", "abcdefg",
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "string-setting"));
-    jqUnit.assertUndefined("Checking non-existent' key",
+    jqUnit.assertUndefined("Checking non-existent 'string' key",
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "unicorn"));
 });
 
@@ -213,7 +213,7 @@ jqUnit.test("Setting single keys via gsettings handler", function () {
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-set", "string-setting"));
     // set and check non-existent key
     gpii.gsettings.setSingleKey("net.gpii.testing.gsettings.single-set", "unicorn", "Mythical");
-    jqUnit.assertUndefined("Checking non-existaent 'string' key",
+    jqUnit.assertUndefined("Checking non-existent 'string' key",
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-set", "unicorn"));
 });
 

--- a/gpii/node_modules/gsettingsBridge/tests/gsettingsTests.js
+++ b/gpii/node_modules/gsettingsBridge/tests/gsettingsTests.js
@@ -193,7 +193,7 @@ jqUnit.test("Getting single keys via gsettings handler", function () {
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "boolean-setting"));
     jqUnit.assertEquals("Checking 'string' key", "abcdefg",
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "string-setting"));
-    jqUnit.assertEquals("Checking non-existent' key", undefined,
+    jqUnit.assertUndefined("Checking non-existent' key",
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "unicorn"));
 });
 
@@ -213,7 +213,7 @@ jqUnit.test("Setting single keys via gsettings handler", function () {
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-set", "string-setting"));
     // set and check non-existent key
     gpii.gsettings.setSingleKey("net.gpii.testing.gsettings.single-set", "unicorn", "Mythical");
-    jqUnit.assertEquals("Checking non-existaent 'string' key", undefined,
+    jqUnit.assertUndefined("Checking non-existaent 'string' key",
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-set", "unicorn"));
 });
 

--- a/gpii/node_modules/gsettingsBridge/tests/gsettingsTests.js
+++ b/gpii/node_modules/gsettingsBridge/tests/gsettingsTests.js
@@ -193,6 +193,8 @@ jqUnit.test("Getting single keys via gsettings handler", function () {
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "boolean-setting"));
     jqUnit.assertEquals("Checking 'string' key", "abcdefg",
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "string-setting"));
+    jqUnit.assertEquals("Checking non-existent' key", undefined,
+        gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-get", "unicorn"));
 });
 
 
@@ -209,6 +211,10 @@ jqUnit.test("Setting single keys via gsettings handler", function () {
     gpii.gsettings.setSingleKey("net.gpii.testing.gsettings.single-set", "string-setting", "Absolutely awesome");
     jqUnit.assertEquals("Checking 'string' key", "Absolutely awesome",
         gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-set", "string-setting"));
+    // set and check non-existent key
+    gpii.gsettings.setSingleKey("net.gpii.testing.gsettings.single-set", "unicorn", "Mythical");
+    jqUnit.assertEquals("Checking non-existaent 'string' key", undefined,
+        gpii.gsettings.getSingleKey("net.gpii.testing.gsettings.single-set", "unicorn"));
 });
 
 jqUnit.test("Setting multiple keys", function () {


### PR DESCRIPTION
@sgithens @javihernandez The problem is in the gpii.gsettings.setSingleKey() and gpii.gsettings.getSingleKey() functions. This pull fixes that.
