### PR TITLE
GPII-2395: XRandR bridge should provide all posible screen resolutions

### DIFF
--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr.cc
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr.cc
@@ -206,15 +206,14 @@ NAN_METHOD(getDisplays) {
         }
 
         v8::Local<v8::Array> available_resolutions = Nan::New<v8::Array>();
-        char *resolution;
         for (int j=0; j<output_info->nmode; j++) {
             XRRModeInfo *mode = find_mode_by_xid(output_info->modes[j], res);
-            asprintf(&resolution, "%dx%d", mode->width, mode->height);
-            available_resolutions->Set(j, Nan::Encode(resolution,
-                                                      strlen(resolution),
-                                                      Nan::UTF8));
-            free(resolution);
-            resolution = NULL;
+            v8::Local<v8::Object> aResolution = Nan::New<v8::Object>();
+            aResolution->Set(Nan::New("width").ToLocalChecked(),
+                             Nan::New(mode->width));
+            aResolution->Set(Nan::New("height").ToLocalChecked(),
+                             Nan::New(mode->height));
+            available_resolutions->Set(j, aResolution);
         }
         output->Set(Nan::New("available_resolutions").ToLocalChecked(),
                     available_resolutions);

--- a/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
+++ b/gpii/node_modules/xrandr/nodexrandr/nodexrandr_tests.js
@@ -20,18 +20,6 @@ var fluid = require("universal"),
     jqUnit = fluid.require("node-jqunit"),
     xrandr = require("./build/Release/nodexrandr.node");
 
-var convert = fluid.registerNamespace("gpii.tests.xrandr.convert");
-convert.toString = function (size) {
-    return size.width + "x" + size.height;
-};
-convert.toSize = function (sizeString) {
-    var wPos = sizeString.indexOf("x");
-    return {
-        width: parseInt(sizeString.substring(0, wPos), 10),
-        height: parseInt(sizeString.substring(wPos + 1), 10)
-    };
-};
-
 jqUnit.module("GPII Xrandr Module");
 
 jqUnit.test("Running tests for Xrandr Bridge", function () {
@@ -57,13 +45,13 @@ jqUnit.test("Running tests for Xrandr Bridge", function () {
     jqUnit.assertFalse("Checking 'setScreenResolution' with impossible size",
                        xrandr.setScreenResolution(-1, -1));
 
-    // Convert the current resolution to a string, and see if there is a
-    // different available resolution to test setScreenResolution().
+    // See if there is a different available resolution to test
+    // setScreenResolution().
     //
-    var resolution0 = convert.toString(display.resolution);
+    var resolution0 = display.resolution;
     var newResolution = fluid.find(display.available_resolutions, function (aResolution) {
         if (resolution0 !== aResolution) {
-            return (convert.toSize(aResolution));
+            return aResolution;
         }
     }, null);
     if (newResolution !== null) {

--- a/gpii/node_modules/xrandr/package.json
+++ b/gpii/node_modules/xrandr/package.json
@@ -3,6 +3,9 @@
   "description": "The xrandrBridge is a Node.js implementation of Xrandr.",
   "version": "0.1.0",
   "author": "Javier Hernández",
+  "contributors": [{
+    "name": "Joseph Scheuhammer"
+  }],
   "bugs": "http://wiki.gpii.net/index.php/Main_Page",
   "homepage": "http://gpii.net/",
   "dependencies": {},

--- a/gpii/node_modules/xrandr/test/xrandrSettingsHandlerTests.js
+++ b/gpii/node_modules/xrandr/test/xrandrSettingsHandlerTests.js
@@ -2,6 +2,7 @@
  * GPII Xrandr Settings Handler Tests
  *
  * Copyright 2013 Emergya
+ * Copyright 2016 OCAD University
  *
  * Licensed under the New BSD license. You may not use this file except in
  * compliance with this License.
@@ -20,39 +21,118 @@ var fluid = require("universal"),
     jqUnit = fluid.require("node-jqunit");
 
 require("xrandr");
+var gpii = fluid.registerNamespace("gpii");
 var xrandr = fluid.registerNamespace("gpii.xrandr");
+var xrandrTests = fluid.registerNamespace("gpii.xrandr.tests");
 
-jqUnit.module("GPII Xrandr Module");
+// Mock settings payload
+xrandrTests.payload = {
+    "org.freedesktop.xrandr": [{
+        settings: {
+            "screen-resolution": {"width": 800, "height": 600}
+        }
+    }]
+};
 
-jqUnit.test("Running tests for Xrandr Bridge", function () {
-    // Check if all required methods are available through the
-    // Xrandr Settings Handler.
-    //
-    var methods = ["getScreenResolution", "setScreenResolution", "get", "set"];
-    for (var method in methods) {
-        jqUnit.assertTrue("Checking availability of method '" + method + "'",
-                          (methods[method] in xrandr));
+xrandrTests.getImplTestData = {
+    "screen-resolution": {
+        get: "gpii.xrandr.tests.getScreenResolution",
     }
+};
 
-    var payload = {
+gpii.xrandr.tests.getScreenResolution = function () {
+    var anXRandR = xrandr();
+    return anXRandR.getScreenResolution();
+};
+
+var XRandR = xrandr();
+jqUnit.module("GPII XRandR Module");
+
+jqUnit.test("XRandR Bridge: Get connected display", function () {
+    var connectedDisplay = XRandR.getConnectedDisplay();
+    jqUnit.assertNotNull("Getting connected display", connectedDisplay);
+    jqUnit.assertEquals("Connected display", "connected", connectedDisplay.status);
+});
+
+jqUnit.test("XRandR Bridge: Get screen resolution", function () {
+    var screenResolution = XRandR.getScreenResolution();
+    jqUnit.assertNotNull("Getting current screen resolution", screenResolution);
+    jqUnit.assertNotEquals("Current screen width", 0, screenResolution.width);
+    jqUnit.assertNotEquals("Current screen height", 0, screenResolution.height);
+});
+
+jqUnit.test("XRandR Bridge: Available screen resolutions", function () {
+    var availableReesolutions = XRandR.getAvailableResolutions();
+    jqUnit.assertNotNull("Available resoiultions array", availableReesolutions);
+    jqUnit.assertNotEquals("Number of availableReesolutions",
+                           0, availableReesolutions.length);
+});
+
+jqUnit.test("XRandR Bridge: Set screen resolution", function () {
+    var currentRez = XRandR.getScreenResolution();
+    var availableRez = XRandR.getAvailableResolutions();
+    var newRez = fluid.copy(currentRez);
+    if (availableRez.length > 1) {
+        newRez = availableRez[1];
+    }
+    XRandR.setScreenResolution(newRez);
+    var sctualRez = XRandR.getScreenResolution();
+    jqUnit.assertDeepEq("Set to new resolution", newRez, sctualRez);
+
+    XRandR.setScreenResolution(currentRez);
+    var sctualRez = XRandR.getScreenResolution();
+    jqUnit.assertDeepEq("Reset to original resolution", currentRez, sctualRez);
+});
+
+jqUnit.test("XRandR Bridge: getImpl()", function () {
+    // Call without passing a settingsRequest.  The current screen resolution
+    // is expected.
+    var actualSettings = XRandR.getImpl();
+    var screenResolution = XRandR.getScreenResolution();
+    var expectedSettings = {
+        "screen-resolution": {
+            width: screenResolution.width,
+            height: screenResolution.height
+        }
+    };
+    jqUnit.assertDeepEq("Return value of getImpl() with no input",
+                        expectedSettings, actualSettings);
+
+    // Call with a test settingsRequest.
+    var actualSettings = XRandR.getImpl(xrandrTests.getImplTestData);
+    var screenResolution = XRandR.getScreenResolution();
+    jqUnit.assertDeepEq("Return value of getImpl() with an inpur",
+                         expectedSettings, actualSettings);
+
+});
+
+jqUnit.test("XRandR Bridge: get() with mock settings payload", function () {
+    var actual = XRandR.get(xrandrTests.payload);
+    var screenResolution = XRandR.getScreenResolution();
+    var expected = {
         "org.freedesktop.xrandr": [{
-            settings: {
-                "screen-resolution": {"width": 800, "height": 600}
+            "settings": {
+                "screen-resolution": {
+                    width: screenResolution.width,
+                    height: screenResolution.height
+                }
             }
         }]
     };
+    jqUnit.assertDeepEq("Return value of get", expected, actual);
+});
 
-    var returnPayload = xrandr.set(payload);
-
+jqUnit.test("XRandR Bridge: set() with mock settings payload", function () {
+    var returnPayload = XRandR.set(xrandrTests.payload);
     jqUnit.assertDeepEq("The resolution is being setted well",
             returnPayload["org.freedesktop.xrandr"][0].settings["screen-resolution"].newValue,
-            payload["org.freedesktop.xrandr"][0].settings["screen-resolution"]);
+            xrandrTests.payload["org.freedesktop.xrandr"][0].settings["screen-resolution"]);
 
-    var newPayload = fluid.copy(payload);
+    var newPayload = fluid.copy(xrandrTests.payload);
     newPayload["org.freedesktop.xrandr"][0].settings["screen-resolution"] =
         returnPayload["org.freedesktop.xrandr"][0].settings["screen-resolution"].oldValue;
 
-    var lastPayload = xrandr.set(newPayload);
+    var lastPayload = XRandR.set(newPayload);
 
     jqUnit.assertDeepEq("The resolution is being restored well",
             returnPayload["org.freedesktop.xrandr"][0].settings["screen-resolution"].oldValue,

--- a/gpii/node_modules/xrandr/xrandr_bridge.js
+++ b/gpii/node_modules/xrandr/xrandr_bridge.js
@@ -23,37 +23,70 @@ var xrandr = require("./nodexrandr/build/Release/nodexrandr.node");
 
 fluid.registerNamespace("gpii.xrandr");
 
-fluid.defaults("gpii.xrandr.getScreenResolution", {
-    gradeNames: "fluid.function",
-    argumentMap: {
+fluid.defaults("gpii.xrandr", {
+    gradeNames: ["fluid.component"],
+    invokers: {
+        getConnectedDisplay: {
+            funcName: "gpii.xrandr.getConnectedDisplay",
+            args: []
+        },
+        getScreenResolution: {
+            funcName: "gpii.xrandr.getScreenResolution",
+            args: []
+        },
+        getAvailableResolutions: {
+            funcName: "gpii.xrandr.getAvailableResolutions",
+            args: ["{that}"]
+        },
+        setScreenResolution: {
+            funcName: "gpii.xrandr.setScreenResolution",
+            args: ["{that}", "{arguments}.0"]
+                             // { width, height }
+        },
+        getImpl: {
+            funcName: "gpii.xrandr.getImpl",
+            args: ["{arguments}.0"]
+                   // settingsRequest payload
+        },
+        get: {
+            funcName: "gpii.xrandr.get",
+            args: ["{that}", "{arguments}.0"]
+                             // array of settings
+        },
+        set: {
+            funcName: "gpii.xrandr.set",
+            args: ["{that}", "{arguments}.0"]
+                             // array of settings
+        }
     }
 });
 
-fluid.defaults("gpii.xrandr.setScreenResolution", {
-    gradeNames: "fluid.function",
-    argumentMap: {
-        value: 0
-    }
-});
-
-gpii.xrandr.getScreenResolution = function () {
+gpii.xrandr.getConnectedDisplay = function () {
     var displayInfo = xrandr.getDisplays();
-    var connectedDisplay = fluid.find_if(displayInfo, function (display) {
+    return fluid.find_if(displayInfo, function (display) {
         return display.status === "connected";
     }, displayInfo[0]);
+};
 
+gpii.xrandr.getScreenResolution = function () {
+    var connectedDisplay = gpii.xrandr.getConnectedDisplay();
     return {
         width: connectedDisplay.resolution.width,
         height: connectedDisplay.resolution.height
     };
 };
 
-gpii.xrandr.setScreenResolution = function (value) {
-    var current = gpii.xrandr.getScreenResolution();
-    if (JSON.stringify(value) === JSON.stringify(current)) {
+gpii.xrandr.getAvailableResolutions = function (that) {
+    var connectedDisplay = that.getConnectedDisplay();
+    return connectedDisplay.available_resolutions;
+};
+
+gpii.xrandr.setScreenResolution = function (that, size) {
+    var current = that.getScreenResolution();
+    if (fluid.model.diff(size, current)) {
         return true;
     } else {
-        return xrandr.setScreenResolution(value.width, value.height);
+        return xrandr.setScreenResolution(size.width, size.height);
     }
 };
 
@@ -78,11 +111,11 @@ gpii.xrandr.getImpl = function (settingsRequest) {
     return settings;
 };
 
-gpii.xrandr.get = function (settingsarray) {
+gpii.xrandr.get = function (that, settingsarray) {
     var app = fluid.copy(settingsarray);
     for (var appId in app) {
         for (var j = 0; j < app[appId].length; j++) {
-            var settings = gpii.xrandr.getImpl(app[appId][j].settings);
+            var settings = that.getImpl(app[appId][j].settings);
 
             var noOptions = { settings: settings };
             app[appId][j] = noOptions;
@@ -91,7 +124,7 @@ gpii.xrandr.get = function (settingsarray) {
     return app;
 };
 
-gpii.xrandr.set = function (settingsarray) {
+gpii.xrandr.set = function (that, settingsarray) {
     var app = fluid.copy(settingsarray);
     for (var appId in app) {
         for (var j = 0; j < app[appId].length; j++) {
@@ -102,8 +135,8 @@ gpii.xrandr.set = function (settingsarray) {
 
                 var oldValue;
                 if (settingKey === "screen-resolution") {
-                    oldValue = gpii.xrandr.getScreenResolution();
-                    gpii.xrandr.setScreenResolution(value);
+                    oldValue = that.getScreenResolution();
+                    that.setScreenResolution(value);
                 } else {
                     var err = "Invalid key: " + settingKey;
                     fluid.fail(err);


### PR DESCRIPTION
@javihernandez, @kaspermarkus Here are changes to the Linux/GNOME XRandR bridge to provide all possible screen resolutions when asked.

I went a little further than just modifying the node add-on and the bridge to provide this information.  I also refactored the bridge into a fluid component.  It was previously a set of namespaced functions -- there a number of `fluid.defaults()` each with a grade of `"fluid.function"`.  Now those functions are invokers within a `gpii.xrandr` fluid component.

One issue, though:  @javihernandez, I'm not clear what the `gpii.xrandr.allSettings` construct at [line 93](https://github.com/klown/linux/blob/GPII-2395/gpii/node_modules/xrandr/xrandr_bridge.js#L93) is for.  I couldn't see where it was actually used outside of the XRandR bridge.  I kept it, and its use inside the bridge, but couldn't actually fit it into the new `gpii.xrandr` component.

Anyhow, let me know what you think.