### PR TITLE
GPII-2158 - Update to Fedora 26

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ ram = ENV["VM_RAM"] || 2048
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "inclusivedesign/fedora24"
+  config.vm.box = "inclusivedesign/fedora26"
 
   # Your working directory will be synced to /home/vagrant/sync in the VM.
   config.vm.synced_folder ".", "#{app_directory}"


### PR DESCRIPTION
[Fedora 26](https://fedoramagazine.org/fedora-26-is-here/) was released today and we've release a [new vagrant box](https://app.vagrantup.com/inclusivedesign/boxes/fedora26) as well.

Built and tested with VirtualBox 5.1.22