### PR TITLE
NOJIRA - Fix Ansible inventory warning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,7 +60,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     sudo ansible-galaxy install -fr /home/vagrant/sync/provisioning/requirements.yml
-    sudo PYTHONUNBUFFERED=1 ansible-playbook /home/vagrant/sync/provisioning/playbook.yml --tags="install,configure" --inventory="localhost,"
+    sudo PYTHONUNBUFFERED=1 ansible-playbook /home/vagrant/sync/provisioning/playbook.yml --tags="install,configure" --inventory="localhost ansible_connection=local,"
   SHELL
 
   # Using config.vm.hostname to set the hostname on Fedora VMs seems to remove the string

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,7 +60,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     sudo ansible-galaxy install -fr /home/vagrant/sync/provisioning/requirements.yml
-    sudo PYTHONUNBUFFERED=1 ansible-playbook /home/vagrant/sync/provisioning/playbook.yml --tags="install,configure"
+    sudo PYTHONUNBUFFERED=1 ansible-playbook /home/vagrant/sync/provisioning/playbook.yml --tags="install,configure" --inventory="localhost,"
   SHELL
 
   # Using config.vm.hostname to set the hostname on Fedora VMs seems to remove the string


### PR DESCRIPTION
Ansible used to include an inventory file that had "localhost". The default inventory now is empty and this warning is shown:

```
    default:  [WARNING]: provided hosts list is empty, only localhost is available. Note
    default: that the implicit localhost does not match 'all'
```

This shows in red in log output and can confuse users.

I'm proposing an inventory is defined on the fly through a command line parameter, just to satisfy Ansible and clean up the logs. This should be harmless.