### PR TITLE
GPII-3093:  Unmask and enable packagekit.service for gpii-linux VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,4 +77,18 @@ Vagrant.configure(2) do |config|
     inline: "/usr/local/bin/edit-hosts.sh",
     run: "always"
 
+  # The Vagrant box is configured with packagekit service disabled and masked.
+  # Packagekit is needed by the linux implementation of the DeviceReporter -- re-enable
+  # here.  If the service is running, the inline script below is a no-op.
+  # Note:  unfortunately, the output on the command line is:
+  #    default: Removed /etc/systemd/system/packagekit.service
+  # But, that actually means that the service is up and running.  What it is
+  # saying is that the service has been unlinked from /dev/null, i.e. working.
+  config.vm.provision "shell",
+    run: "always",
+    inline: <<-SHELL
+      sudo systemctl unmask packagekit.service
+      sudo systemctl start packagekit.service
+   SHELL
+
 end


### PR DESCRIPTION
@javihernandez Here is a fix for gpii-linux where the packagekit.service is re-enabled.

I added a script to the Vagrantfile that unmasks and starts the packagekit.service.  That service is masked in the Vagrant box, currently "inclusivedesign/fedora27".  That box is shared among gpii-universal, gpii-linux, and fluid infusion, but only gpii-linux needs Packagekit enabled.  Isolating the re-enabling in linux's Vagrantfile is a good approach.
